### PR TITLE
Support DSN config and processing ENV variables

### DIFF
--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -66,6 +66,10 @@
         "database": {
             "type": "object",
             "properties": {
+                "dsn": {
+                    "type": ["string"],
+                    "minLength": 1
+                },
                 "driver": {
                     "type": "string",
                     "enum": ["pdo_mysql"]

--- a/src/Console/Command/DumpCommand.php
+++ b/src/Console/Command/DumpCommand.php
@@ -99,7 +99,7 @@ class DumpCommand extends Command
 
             // Prompt the password if required
             $database = $this->config->get('database');
-            if (!isset($database['password'])) {
+            if (!isset($database['password']) && !isset($database['dsn'])) {
                 $password = $this->promptPassword($input, $output);
                 $database['password'] = $password;
                 $this->config->set('database', $database);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -106,6 +106,11 @@ class Database implements DatabaseInterface
         // Get the connection parameters from the config
         $params = $config->getConnectionParams();
 
+        // A DSN holds all config parameters that we need to build the connection
+        if (isset($params['dsn'])) {
+            return DriverManager::getConnection(['url' => $params]);
+        }
+
         // Rename parameters that do not match Doctrine naming conventions (name -> dbname)
         $params['dbname'] = $params['name'];
         unset($params['name']);

--- a/src/Dumper/Config/DatabaseConfig.php
+++ b/src/Dumper/Config/DatabaseConfig.php
@@ -87,6 +87,13 @@ class DatabaseConfig
      */
     private function prepareConfig(array $params)
     {
+        // A DSN holds all config and is valid standalone
+        if (isset($params['dsn'])) {
+            $this->connectionParams['dsn'] = (string) $params['dsn'];
+
+            return;
+        }
+
         // The database name is mandatory, no matter what driver is used
         // (this will require some refactoring if SQLite compatibility is added)
         if (!isset($params['name'])) {


### PR DESCRIPTION
## PR Checklist

Please check if your pull request fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/Smile-SA/gdpr-dump/blob/master/CONTRIBUTING.md.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently, you must set the database config (username, password, etc.) manually in the config. It is not possible to use a DSN nor to pass environment variables.

## What is the new behavior?
<!-- Please describe the new behavior introduced by your changes. -->

The aim is to pass the database connection params as DSN, as it is configured as DSN already in the application. Defining the database DSN is state-of-the-art for most Symfony applications.

It should be possible to use the following configuration:
```yml
database:
  dsn: '%env(DATABASE_URL)%'
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
```
[ ] Yes
[x] No
```

## TODO
- [x] Building a database connection from DSN
- [ ] Processing env vars

## Other information

This Pull Request is WIP and definitely needs some help/feedback on the following questions:
- [ ] At this point, env vars do not get processed. Usually, I would go and use symfony/config to parsing and processing the configuration yml. But it looks like you are processing the configuration yml differently. How do we proceed to resolve the '%env(DATABASE_URL)%'
