### PR TITLE
Allow referencing environment variables in the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## WIP
+
+- Allow referencing environment variables in the configuration
+
 ## [1.1.1] - 2020-05-13
 [1.1.1]: https://github.com/Smile-SA/gdpr-dump/compare/1.1.0...1.1.1
 

--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -27,9 +27,12 @@ services:
         arguments:
             - '@Smile\GdprDump\Config\Config'
             - '@Smile\GdprDump\Config\Parser\YamlParser'
+            - ['@Smile\GdprDump\Config\Processor\EnvVarProcessor']
             - '@Smile\GdprDump\Config\Resolver\PathResolver'
 
     Smile\GdprDump\Config\Parser\YamlParser: ~
+
+    Smile\GdprDump\Config\Processor\EnvVarProcessor: ~
 
     Smile\GdprDump\Config\Resolver\PathResolver:
         arguments:

--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -15,6 +15,7 @@
     - [Skipping Data Conversion](#user-content-skipping-data-conversion)
     - [Sharing Converter Results](#user-content-sharing-converter-results)
 - [User-Defined Variables](#user-content-user-defined-variables)
+- [Environments Variables](#user-content-environment-variables)
 - [Version-specific Configuration](#user-content-version-specific-configuration)
 
 ## Overriding Configuration
@@ -88,8 +89,6 @@ Available parameters:
 | **unix_socket** | N | | Name of the socket to use. |
 | **driver** | N | `'pdo_mysql'` | Database driver. Only `pdo_mysql` is supported as of now. |
 | **driver_options** | N | `[]` | An array of [PDO settings](https://www.php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants). |
-
-If command-line options are specified (e.g. `--user`), they will have priority over the parameter in the configuration file.
 
 ## Dump Settings
 
@@ -351,7 +350,7 @@ Notes:
   If the parameter is missing somewhere, it can result in a infinite loop situation.
 - This feature is not used in the default templates (`magento2`, ...), because it may require a lot of memory, depending on the size of the tables.
 
-### User-Defined Variables
+## User-Defined Variables
 
 It is possible to store SQL query results in user-defined variables:
 
@@ -382,7 +381,37 @@ tables:
             condition: '{{attribute_id}} == @firstname_attribute_id'
 ```
 
-### Version-specific Configuration
+## Environment Variables
+
+You can use environment variables with the following syntax:
+
+```yaml
+database:
+    host: '%env(DATABASE_HOST)%'
+    user: '%env(DATABASE_USER)%'
+    password: '%env(DATABASE_PASSWORD)%'
+    name: '%env(DATABASE_NAME)%'
+```
+
+You can also set the variable type with the following syntax:
+
+```yaml
+tables:
+    cache:
+        truncate: '%env(bool:TRUNCATE_CACHE_TABLE)%'
+```
+
+Available types: string (default), bool, int, float, json.
+
+The JSON type can be used to define array values. For example:
+
+```yaml
+tables_blacklist: '%env(json:TABLES_BLACKLIST)%'
+```
+
+Example value of the environment variable: `["table1", "table2", "table3"]`.
+
+## Version-specific Configuration
 
 The `if_version` property allows to define configuration that will be read only if the version of your application matches a requirement.
 

--- a/src/Config/Processor/EnvVarProcessor.php
+++ b/src/Config/Processor/EnvVarProcessor.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Config\Processor;
+
+use RuntimeException;
+use UnexpectedValueException;
+
+class EnvVarProcessor implements ProcessorInterface
+{
+    /**
+     * Environment variable name format.
+     */
+    const VAR_NAME_REGEX = '[A-Z][A-Z0-9_]*';
+
+    /**
+     * @var string[]
+     */
+    private $types = [
+        'string',
+        'bool',
+        'int',
+        'float',
+        'json',
+    ];
+
+    /**
+     * @inheritdoc
+     * @throws RuntimeException
+     * @throws UnexpectedValueException
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    public function process($value)
+    {
+        if (!is_string($value) || strpos($value, '%env(') !== 0 || substr($value, -2) !== ')%') {
+            return $value;
+        }
+
+        $name = substr($value, 5, -2);
+        list($type, $name) = $this->parse($name);
+
+        if (!array_key_exists($name, $_SERVER)) {
+            throw new RuntimeException(sprintf('The environment variable "%s" is not defined.', $name));
+        }
+
+        $value = $_SERVER[$name];
+
+        if ($type === 'json') {
+            return $this->decodeJson($value, $name);
+        }
+
+        settype($value, $type);
+
+        return $value;
+    }
+
+    /**
+     * Parse "%env($name)%".
+     *
+     * @param string $name
+     * @return array
+     * @throws UnexpectedValueException
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
+    private function parse(string $name): array
+    {
+        $pos = strpos($name, ':');
+
+        if ($pos === false) {
+            $type = 'string';
+        } else {
+            $type = substr($name, 0, $pos);
+            $name = substr($name, $pos + 1);
+        }
+
+        if (!in_array($type, $this->types, true)) {
+            throw new UnexpectedValueException(
+                sprintf('Invalid type "%s". Expected: %s.', $type, implode(', ', $this->types))
+            );
+        }
+
+        if ($name === '') {
+            throw new UnexpectedValueException('Environment variable name must not be empty.');
+        }
+
+        if (!preg_match('/^' . self::VAR_NAME_REGEX . '$/', $name)) {
+            throw new UnexpectedValueException(
+                sprintf('"%s" is not a valid environment variable name. Expected format: "[A-Z][A-Z0-9_]*".', $name)
+            );
+        }
+
+        return [$type, $name];
+    }
+
+    /**
+     * Decode a JSON-encoded string.
+     *
+     * @param string $value
+     * @param string $name
+     * @return mixed
+     * @throws RuntimeException
+     */
+    private function decodeJson(string $value, string $name)
+    {
+        $value = json_decode($value, true);
+
+        if ($value === null) {
+            throw new RuntimeException(
+                sprintf('Failed to parse the JSON value of the environment variable "%s".', $name)
+            );
+        }
+
+        return $value;
+    }
+}

--- a/src/Config/Processor/ProcessorInterface.php
+++ b/src/Config/Processor/ProcessorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Config\Processor;
+
+interface ProcessorInterface
+{
+    /**
+     * Process a config value.
+     *
+     * @param mixed $value
+     */
+    public function process($value);
+}

--- a/src/Console/Command/DumpCommand.php
+++ b/src/Console/Command/DumpCommand.php
@@ -100,8 +100,7 @@ class DumpCommand extends Command
             // Prompt the password if required
             $database = $this->config->get('database');
             if (!isset($database['password'])) {
-                $password = $this->promptPassword($input, $output);
-                $database['password'] = $password;
+                $database['password'] = $this->promptPassword($input, $output);
                 $this->config->set('database', $database);
             }
 

--- a/tests/unit/Config/Processor/EnvVarProcessorTest.php
+++ b/tests/unit/Config/Processor/EnvVarProcessorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Tests\Unit\Config\Processor;
+
+use RuntimeException;
+use Smile\GdprDump\Config\Processor\EnvVarProcessor;
+use Smile\GdprDump\Tests\Unit\TestCase;
+use UnexpectedValueException;
+
+class EnvVarProcessorTest extends TestCase
+{
+    /**
+     * @inheritdoc
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    protected function tearDown()
+    {
+        unset($_SERVER['TEST_ENV_VAR']);
+    }
+
+    /**
+     * Assert that normal values are not processed.
+     */
+    public function testNormalValuesNotProcessed()
+    {
+        $processor = new EnvVarProcessor();
+
+        $value = $processor->process('12345');
+        $this->assertSame('12345', $value);
+
+        $value = $processor->process('env(TEST_ENV_VAR)');
+        $this->assertSame('env(TEST_ENV_VAR)', $value);
+    }
+
+    /**
+     * Assert that scalar environment variables are processed successfully.
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    public function testScalarEnvVar()
+    {
+        $processor = new EnvVarProcessor();
+        $_SERVER['TEST_ENV_VAR'] = '12345';
+
+        $value = $processor->process('%env(TEST_ENV_VAR)%');
+        $this->assertSame($_SERVER['TEST_ENV_VAR'], $value);
+
+        $value = $processor->process('%env(string:TEST_ENV_VAR)%');
+        $this->assertSame($_SERVER['TEST_ENV_VAR'], $value);
+
+        $value = $processor->process('%env(bool:TEST_ENV_VAR)%');
+        $this->assertSame(true, $value);
+
+        $value = $processor->process('%env(int:TEST_ENV_VAR)%');
+        $this->assertSame(12345, $value);
+
+        $value = $processor->process('%env(float:TEST_ENV_VAR)%');
+        $this->assertSame(12345.0, $value);
+    }
+
+    /**
+     * Assert that array environment variables are processed successfully.
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    public function testJsonEnvVar()
+    {
+        $processor = new EnvVarProcessor();
+        $_SERVER['TEST_ENV_VAR'] = '{"key": "value"}';
+
+        $value = $processor->process('%env(json:TEST_ENV_VAR)%');
+        $this->assertSame(['key' => 'value'], $value);
+    }
+
+    /**
+     * Assert that an exception is thrown when the JSON data is invalid.
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    public function testInvalidJson()
+    {
+        $processor = new EnvVarProcessor();
+        $_SERVER['TEST_ENV_VAR'] = 'invalidData';
+
+        $this->expectException(RuntimeException::class);
+        $processor->process('%env(json:TEST_ENV_VAR)%');
+    }
+
+    /**
+     * Assert that an exception is thrown when the environment variable is not defined.
+     */
+    public function testUndefinedEnvVar()
+    {
+        $processor = new EnvVarProcessor();
+
+        $this->expectException(RuntimeException::class);
+        $processor->process('%env(NOT_DEFINED)%');
+    }
+
+    /**
+     * Assert that an exception is thrown when the environment variable name is not specified.
+     */
+    public function testEmptyVariableName()
+    {
+        $processor = new EnvVarProcessor();
+
+        $this->expectException(UnexpectedValueException::class);
+        $processor->process('%env()%');
+    }
+
+    /**
+     * Assert that an exception is thrown when the environment variable name and type are not specified.
+     */
+    public function testEmptyVariableNameAndType()
+    {
+        $processor = new EnvVarProcessor();
+
+        $this->expectException(UnexpectedValueException::class);
+        $processor->process('%env(:)%');
+    }
+
+    /**
+     * Assert that an exception is thrown when the environment variable type is not specified.
+     */
+    public function testEmptyVariableType()
+    {
+        $processor = new EnvVarProcessor();
+
+        $this->expectException(UnexpectedValueException::class);
+        $processor->process('%env(:ENV_VAR)%');
+    }
+
+    /**
+     * Assert that an exception is thrown when the environment variable name is invalid.
+     */
+    public function testInvalidVariableName()
+    {
+        $processor = new EnvVarProcessor();
+
+        $this->expectException(UnexpectedValueException::class);
+        $processor->process('%env(invalidName)%');
+    }
+
+    /**
+     * Assert that an exception is thrown when the environment variable type is invalid.
+     */
+    public function testInvalidVariableType()
+    {
+        $processor = new EnvVarProcessor();
+
+        $this->expectException(UnexpectedValueException::class);
+        $processor->process('%env(invalidType:ENV_VAR)%');
+    }
+}

--- a/tests/unit/Resources/config/templates/test.yaml
+++ b/tests/unit/Resources/config/templates/test.yaml
@@ -1,6 +1,8 @@
 ---
 extends: 'test_parent.yaml'
-version: '1.0.0'
+
+dump:
+    output: '%env(DUMP_OUTPUT)%'
 
 tables:
     table1:


### PR DESCRIPTION
Add support for setting an environment variable named `GDPR_DUMP_DATABASE_PASSWORD`.

It takes the precedence over the value from the configuration file (if any).
This allows to set the database password from shell scripts.