### PR TITLE
[RFC] Allow tables and converters that where inherited from the extended template to be unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## WIP
 
+- Allow unsetting config declared in config templates
 - Add missing type hint in table filter extension
 
 ## [2.0.2] - 2020-07-28

--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -16,6 +16,7 @@
     - [Sharing Converter Results](#user-content-sharing-converter-results)
 - [User-Defined Variables](#user-content-user-defined-variables)
 - [Environments Variables](#user-content-environment-variables)
+- [Unsetting Values Declared in Config Templates](#user-content-unsetting-values-declared-in-config-templates)
 - [Version-specific Configuration](#user-content-version-specific-configuration)
 
 ## Overriding Configuration
@@ -410,6 +411,50 @@ tables_blacklist: '%env(json:TABLES_BLACKLIST)%'
 ```
 
 Example value of the environment variable: `["table1", "table2", "table3"]`.
+
+## Unsetting Values Declared in Config Templates
+
+It is possible to unset values that were declared in a parent config file, by setting them to `null`.
+
+**Warning**: setting a value to `null` is only allowed if it is already defined in a parent config file.
+
+Example - removing the whole config of a table (converters, filters, limit...):
+
+```yaml
+extends: 'magento2'
+tables:
+    admin_user: ~
+```
+
+Example - removing all converters of a table:
+
+```yaml
+extends: 'magento2'
+tables:
+    admin_user:
+        converters: ~
+```
+
+Example - removing a specific converter:
+
+```yaml
+extends: 'magento2'
+tables:
+    admin_user:
+        converters:
+            email: ~
+```
+
+Alternatively, converters can be disabled with setting the `disabled` parameter to `true`:
+
+```yaml
+extends: 'magento2'
+tables:
+    admin_user:
+        converters:
+            email:
+                disabled: true
+```
 
 ## Version-specific Configuration
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -78,6 +78,15 @@ class Config implements ConfigInterface
                 if (is_array($value) && is_array($data[$key])) {
                     // Merge values
                     $data[$key] = $this->mergeArray($data[$key], $value);
+
+                    // If a key of the array was unset and the array is empty as a result, unset it
+                    // This is necessary because JSON schema validation does not allow empty array as object values
+                    if (!empty($value) && empty($data[$key])) {
+                        unset($data[$key]);
+                    }
+                } elseif ($value === null && is_array($data[$key])) {
+                    // Remove array key (allows to remove an existing config item by setting it to null)
+                    unset($data[$key]);
                 } else {
                     // Overwrite value
                     $data[$key] = $value;

--- a/tests/unit/Config/ConfigLoaderTest.php
+++ b/tests/unit/Config/ConfigLoaderTest.php
@@ -42,6 +42,9 @@ class ConfigLoaderTest extends TestCase
 
         $expectedSubset = ['table4' => ['orderBy' => 'field1']];
         $this->assertArraySubset($expectedSubset, $tablesConfig);
+
+        // Assert that the converters of table 4 were removed (by setting it to null in the child config file)
+        $this->assertArrayNotHasKey('converters', $tablesConfig['table4']);
     }
 
     /**


### PR DESCRIPTION
## PR Checklist

Please check if your pull request fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Smile-SA/gdpr-dump/blob/master/CONTRIBUTING.md.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently it is not possible to extend a template (like the Magento 2 template) and unset or override specific parts that have already been configured.

Use case: We use the gdpr-dump to export our production database to our staging database, but we want to maintain the `admin_user` table in it's original state to allow our employees to easily test new features (in the admin) without having to worry about their credentials.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior introduced by your changes. -->
It is not possible to 'unset' existing tables that were inherited by using the `extends` configuration.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
```
[ ] Yes
[ x ] No
```

## Other information
<!-- Add any other context here. -->
All tests related to the changed code are green. There seem to be some unrelated phpmd errors.
