### PR TITLE
Reduce phar file size by excluding Faker translation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix conditions not working properly in functional tests
 - Replace deprecated Doctrine functions
-- Slightly reduced phar file size
+- Reduced phar file size by ~50%
 
 ## [2.0.3] - 2020-10-05
 [2.0.3]: https://github.com/Smile-SA/gdpr-dump/compare/2.0.2...2.0.3

--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use Smile\GdprDump\AppKernel;
 use Smile\GdprDump\Compiler;
 
 $basePath = dirname(__DIR__);
@@ -11,9 +12,14 @@ require $basePath . '/app/bootstrap.php';
 // Prepare the file name
 $fileName = $basePath . '/build/dist/gdpr-dump.phar';
 
+// Get the locale
+$application = new AppKernel();
+$application->boot();
+$locale = $application->getContainer()->getParameter('faker.locale');
+
 try {
     // Create the phar file
-    $compiler = new Compiler();
+    $compiler = new Compiler($locale);
     $compiler->compile($fileName);
 } catch (RuntimeException $e) {
     die('ERROR: ' . $e->getMessage() . "\n");


### PR DESCRIPTION
The faker library is bundled with a lot of translations.
These translations are not used at all in this project, removing them from the phar file reduces the file size by approximately 50%.
