### PR TITLE
Adds configurability of faker locale

### DIFF
--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -47,6 +47,9 @@
                 "type": ["string", "number"],
                 "minLength": 1
             }
+        },
+        "faker": {
+            "$ref": "#/definitions/faker"
         }
     },
     "additionalProperties": false,

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -279,6 +279,15 @@
                 }
             },
             "additionalProperties": false
+        },
+        "faker": {
+            "type": "object",
+            "properties": {
+                "locale": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -22,6 +22,9 @@
         "dump": {
             "$ref": "#/definitions/dump"
         },
+        "faker": {
+            "$ref": "#/definitions/faker"
+        },
         "variables": {
             "type": "object",
             "additionalProperties": {
@@ -47,9 +50,6 @@
                 "type": ["string", "number"],
                 "minLength": 1
             }
-        },
-        "faker": {
-            "$ref": "#/definitions/faker"
         }
     },
     "additionalProperties": false,
@@ -197,6 +197,15 @@
             },
             "additionalProperties": false
         },
+        "faker": {
+            "type": "object",
+            "properties": {
+                "locale": {
+                    "type": ["string", "null"]
+                }
+            },
+            "additionalProperties": false
+        },
         "table": {
             "type": "object",
             "properties": {
@@ -279,15 +288,6 @@
                 },
                 "disabled": {
                     "type": "boolean"
-                }
-            },
-            "additionalProperties": false
-        },
-        "faker": {
-            "type": "object",
-            "properties": {
-                "locale": {
-                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -2,7 +2,7 @@
 parameters:
     config.schema_file: '%app_root%/app/config/schema.json'
     config.templates_dir: '%app_root%/app/config/templates'
-    faker.locale: 'en_US'
+    faker.locale: '%config.faker.locale%'
 
 services:
     _defaults:

--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -2,7 +2,6 @@
 parameters:
     config.schema_file: '%app_root%/app/config/schema.json'
     config.templates_dir: '%app_root%/app/config/templates'
-    faker.locale: '%config.faker.locale%'
 
 services:
     _defaults:
@@ -61,5 +60,3 @@ services:
 
     faker.service:
         class: 'Smile\GdprDump\Faker\FakerService'
-        arguments:
-            - {locale: '%faker.locale%'}

--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -2,6 +2,10 @@
 parameters:
     config.schema_file: '%app_root%/app/config/schema.json'
     config.templates_dir: '%app_root%/app/config/templates'
+    faker.locale: 'en_US'
+    faker.installed_locales:
+        - 'en_US'
+        - 'fr_FR'
 
 services:
     _defaults:
@@ -45,6 +49,7 @@ services:
         public: true # used by functional tests
         arguments:
             - '@converter.factory'
+            - '@faker.service'
 
     dumper.config:
         class: 'Smile\GdprDump\Config\Config'
@@ -60,5 +65,6 @@ services:
 
     faker.service:
         class: 'Smile\GdprDump\Faker\FakerService'
+        public: true
         arguments:
-            - '@dumper.config'
+            - '%faker.locale%'

--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -60,3 +60,5 @@ services:
 
     faker.service:
         class: 'Smile\GdprDump\Faker\FakerService'
+        arguments:
+            - '@dumper.config'

--- a/bin/compile
+++ b/bin/compile
@@ -15,11 +15,11 @@ $fileName = $basePath . '/build/dist/gdpr-dump.phar';
 // Get the locale
 $application = new AppKernel();
 $application->boot();
-$locale = $application->getContainer()->getParameter('faker.locale');
+$locales = $application->getContainer()->getParameter('faker.installed_locales');
 
 try {
     // Create the phar file
-    $compiler = new Compiler($locale);
+    $compiler = new Compiler($locales);
     $compiler->compile($fileName);
 } catch (RuntimeException $e) {
     die('ERROR: ' . $e->getMessage() . "\n");

--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -481,3 +481,16 @@ The [magento2 template](../app/config/templates/magento2.yaml) uses that feature
 
 There is little point to use this feature in your custom configuration file(s).
 It is mainly used to provide default config templates that are compatible with all versions of a framework.
+
+### Faker Locale
+
+In order to customize the locale used in faker formatters, the locale can be set using the `faker.locale` parameter.
+
+```yaml
+faker:
+    locale: 'de_DE'
+```
+
+The locale setting defaults to `en_US`.
+
+Available locales can be found in the official [faker documentation](https://fakerphp.github.io/).

--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -18,9 +18,9 @@
 - [Advanced Configuration](#user-content-advanced-configuration)
     - [Environments Variables](#user-content-environment-variables)
     - [SQL Variables](#user-content-sql-variables)
+    - [Faker Locale](#user-content-faker-locale)
     - [Unsetting Values Declared in Config Templates](#user-content-unsetting-values-declared-in-config-templates)
     - [Version-specific Configuration](#user-content-version-specific-configuration)
-    - [Faker Locale](#user-content-faker-locale)
 
 ## Templates
 
@@ -419,6 +419,26 @@ tables:
             condition: '{{attribute_id}} == @firstname_attribute_id'
 ```
 
+### Faker Locale
+
+By default, the locale used in faker formatters is `en_US`.
+It can be changed with the following setting:
+
+```yaml
+faker:
+    locale: 'de_DE'
+```
+
+Available locales can be found in the official [faker documentation](https://fakerphp.github.io/).
+
+**Warning**: the default phar distribution only includes the "en_US" locale.
+To use additional locales, you must compile your own phar file:
+
+1. Clone the project.
+2. Add your locale to the parameter `faker.installed_locales` in app/config/services.yaml.
+3. Run the following command: `php -d phar.readonly=off bin/compile`.
+   This will create a file named "gdpr-dump.phar" in the folder "build/dist".
+
 ### Unsetting Values Declared in Config Templates
 
 It is possible to unset values that were declared in a parent config file, by setting them to `null`.
@@ -482,16 +502,3 @@ The [magento2 template](../app/config/templates/magento2.yaml) uses that feature
 
 There is little point to use this feature in your custom configuration file(s).
 It is mainly used to provide default config templates that are compatible with all versions of a framework.
-
-### Faker Locale
-
-In order to customize the locale used in faker formatters, the locale can be set using the `faker.locale` parameter.
-
-```yaml
-faker:
-    locale: 'de_DE'
-```
-
-The locale setting defaults to `en_US`.
-
-Available locales can be found in the official [faker documentation](https://fakerphp.github.io/).

--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -20,6 +20,7 @@
     - [SQL Variables](#user-content-sql-variables)
     - [Unsetting Values Declared in Config Templates](#user-content-unsetting-values-declared-in-config-templates)
     - [Version-specific Configuration](#user-content-version-specific-configuration)
+    - [Faker Locale](#user-content-faker-locale)
 
 ## Templates
 

--- a/docs/02-converters.md
+++ b/docs/02-converters.md
@@ -550,7 +550,7 @@ tables:
                     arguments: ['{{value}}']
 ```
 
-The faker locale can be set in the [configuration file](01-configuration.md) and defaults to `en_US`.
+The faker locale can be set in the [configuration file](01-configuration.md#user-content-faker-locale) and defaults to `en_US`.
 
 ## [chain](../src/Converter/Proxy/Chain.php)
 

--- a/docs/02-converters.md
+++ b/docs/02-converters.md
@@ -550,6 +550,8 @@ tables:
                     arguments: ['{{value}}']
 ```
 
+The faker locale can be set in the [configuration file](01-configuration.md) and defaults to `en_US`.
+
 ## [chain](../src/Converter/Proxy/Chain.php)
 
 This converter executes a list of converters.

--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use UnexpectedValueException;
 
 /**
  * @codeCoverageIgnore
@@ -95,6 +96,7 @@ class AppKernel
      * Build the service container.
      *
      * @return ContainerInterface
+     * @throws UnexpectedValueException
      */
     private function buildContainer(): ContainerInterface
     {
@@ -106,6 +108,15 @@ class AppKernel
 
         $container->setParameter('app_root', $basePath);
         $container->compile();
+
+        $locale = $container->getParameter('faker.locale');
+        $installedLocales = $container->getParameter('faker.installed_locales');
+
+        if (!in_array($locale, $installedLocales, true)) {
+            throw new UnexpectedValueException(
+                sprintf('Locale "%s" is missing from "faker.installed_locales" in app/config/services.yaml.', $locale)
+            );
+        }
 
         return $container;
     }

--- a/src/Database/Config.php
+++ b/src/Database/Config.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Smile\GdprDump\Dumper\Config;
+namespace Smile\GdprDump\Database;
 
 use UnexpectedValueException;
 
-class DatabaseConfig
+class Config implements ConfigInterface
 {
     /**
      * @var string
@@ -39,9 +39,7 @@ class DatabaseConfig
     }
 
     /**
-     * Get the database driver.
-     *
-     * @return string
+     * @inheritdoc
      */
     public function getDriver(): string
     {
@@ -49,9 +47,7 @@ class DatabaseConfig
     }
 
     /**
-     * Get the driver options.
-     *
-     * @return array
+     * @inheritdoc
      */
     public function getDriverOptions(): array
     {
@@ -59,9 +55,7 @@ class DatabaseConfig
     }
 
     /**
-     * Get the connection parameters (host, port, user...).
-     *
-     * @return array
+     * @inheritdoc
      */
     public function getConnectionParams(): array
     {
@@ -69,10 +63,7 @@ class DatabaseConfig
     }
 
     /**
-     * Get the value of a connection parameter.
-     *
-     * @param string $name
-     * @return mixed
+     * @inheritdoc
      */
     public function getConnectionParam(string $name)
     {

--- a/src/Database/ConfigInterface.php
+++ b/src/Database/ConfigInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Database;
+
+interface ConfigInterface
+{
+    /**
+     * Get the database driver.
+     *
+     * @return string
+     */
+    public function getDriver(): string;
+
+    /**
+     * Get the driver options.
+     *
+     * @return array
+     */
+    public function getDriverOptions(): array;
+
+    /**
+     * Get the connection parameters (host, port, user...).
+     *
+     * @return array
+     */
+    public function getConnectionParams(): array;
+
+    /**
+     * Get the value of a connection parameter.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function getConnectionParam(string $name);
+}

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -11,7 +11,6 @@ use Smile\GdprDump\Database\Driver\DriverInterface;
 use Smile\GdprDump\Database\Driver\MysqlDriver;
 use Smile\GdprDump\Database\Metadata\MetadataInterface;
 use Smile\GdprDump\Database\Metadata\MysqlMetadata;
-use Smile\GdprDump\Dumper\Config\DatabaseConfig;
 use UnexpectedValueException;
 
 /**
@@ -42,12 +41,18 @@ class Database implements DatabaseInterface
     private $metadata;
 
     /**
-     * @param DatabaseConfig $config
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
+     * @param ConfigInterface $config
      * @throws Exception
      * @throws UnexpectedValueException
      */
-    public function __construct(DatabaseConfig $config)
+    public function __construct(ConfigInterface $config)
     {
+        $this->config = $config;
         $this->connection = $this->createConnection($config);
         $driver = $config->getDriver();
 
@@ -95,13 +100,21 @@ class Database implements DatabaseInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getConfig(): ConfigInterface
+    {
+        return $this->config;
+    }
+
+    /**
      * Create a Doctrine connection.
      *
-     * @param DatabaseConfig $config
+     * @param ConfigInterface $config
      * @return Connection
      * @throws Exception
      */
-    private function createConnection(DatabaseConfig $config): Connection
+    private function createConnection(ConfigInterface $config): Connection
     {
         // Get the connection parameters from the config
         $params = $config->getConnectionParams();

--- a/src/Database/DatabaseInterface.php
+++ b/src/Database/DatabaseInterface.php
@@ -30,4 +30,11 @@ interface DatabaseInterface
      * @return MetadataInterface
      */
     public function getMetadata(): MetadataInterface;
+
+    /**
+     * Get the database config.
+     *
+     * @return ConfigInterface
+     */
+    public function getConfig(): ConfigInterface;
 }

--- a/src/Dumper/Config/DumperConfig.php
+++ b/src/Dumper/Config/DumperConfig.php
@@ -50,6 +50,13 @@ class DumperConfig
     /**
      * @var array
      */
+    private $fakerSettings = [
+        'locale' => null,
+    ];
+
+    /**
+     * @var array
+     */
     private $dumpSettings = [
         'output' => 'php://stdout',
         'compress' => Mysqldump::NONE,
@@ -81,6 +88,7 @@ class DumperConfig
 
     /**
      * @param ConfigInterface $config
+     * @throws UnexpectedValueException
      */
     public function __construct(ConfigInterface $config)
     {
@@ -98,13 +106,23 @@ class DumperConfig
     }
 
     /**
-     * Get the dump settings.
+     * Get dump settings.
      *
      * @return array
      */
     public function getDumpSettings(): array
     {
         return $this->dumpSettings;
+    }
+
+    /**
+     * Get faker settings.
+     *
+     * @return array
+     */
+    public function getFakerSettings(): array
+    {
+        return $this->fakerSettings;
     }
 
     /**
@@ -195,11 +213,15 @@ class DumperConfig
      * Prepare the config.
      *
      * @param ConfigInterface $config
+     * @throws UnexpectedValueException
      */
     private function prepareConfig(ConfigInterface $config): void
     {
         // Dump settings
         $this->prepareDumpSettings($config);
+
+        // Faker settings
+        $this->prepareFakerSettings($config);
 
         // Tables config
         $this->prepareTablesConfig($config);
@@ -215,9 +237,10 @@ class DumperConfig
     }
 
     /**
-     * Prepare the dump settings.
+     * Prepare dump settings.
      *
      * @param ConfigInterface $config
+     * @throws UnexpectedValueException
      */
     private function prepareDumpSettings(ConfigInterface $config): void
     {
@@ -242,9 +265,29 @@ class DumperConfig
     }
 
     /**
+     * Prepare faker settings.
+     *
+     * @param ConfigInterface $config
+     * @throws UnexpectedValueException
+     */
+    private function prepareFakerSettings(ConfigInterface $config): void
+    {
+        $settings = $config->get('faker', []);
+
+        foreach ($settings as $param => $value) {
+            if (!array_key_exists($param, $this->fakerSettings)) {
+                throw new UnexpectedValueException(sprintf('Invalid faker setting "%s".', $param));
+            }
+
+            $this->fakerSettings[$param] = $value;
+        }
+    }
+
+    /**
      * Prepare the tables configuration.
      *
      * @param ConfigInterface $config
+     * @throws UnexpectedValueException
      */
     private function prepareTablesConfig(ConfigInterface $config): void
     {

--- a/src/Faker/FakerService.php
+++ b/src/Faker/FakerService.php
@@ -16,19 +16,16 @@ class FakerService
     private $generator;
 
     /**
-     * @var array
+     * @var ConfigInterface
      */
-    private $options;
+    private $config;
 
     /**
      * @param ConfigInterface $config
-     * @param array $options
      */
-    public function __construct(ConfigInterface $config, array $options = [])
+    public function __construct(ConfigInterface $config)
     {
-        $this->options = $options + [
-            'locale' => $config->get('faker.locale', Factory::DEFAULT_LOCALE),
-        ];
+        $this->config = $config;
     }
 
     /**
@@ -39,7 +36,8 @@ class FakerService
     public function getGenerator(): Generator
     {
         if ($this->generator === null) {
-            $this->generator = Factory::create($this->options['locale']);
+            $locale = $this->config->get('faker', [])['locale'] ?? Factory::DEFAULT_LOCALE;
+            $this->generator = Factory::create($locale);
         }
 
         return $this->generator;

--- a/src/Faker/FakerService.php
+++ b/src/Faker/FakerService.php
@@ -6,6 +6,7 @@ namespace Smile\GdprDump\Faker;
 
 use Faker\Factory;
 use Faker\Generator;
+use Smile\GdprDump\Config\ConfigInterface;
 
 class FakerService
 {
@@ -20,12 +21,13 @@ class FakerService
     private $options;
 
     /**
+     * @param ConfigInterface $config
      * @param array $options
      */
-    public function __construct(array $options = [])
+    public function __construct(ConfigInterface $config, array $options = [])
     {
         $this->options = $options + [
-            'locale' => Factory::DEFAULT_LOCALE,
+            'locale' => $config->get('faker.locale', Factory::DEFAULT_LOCALE),
         ];
     }
 

--- a/src/Faker/FakerService.php
+++ b/src/Faker/FakerService.php
@@ -16,16 +16,16 @@ class FakerService
     private $generator;
 
     /**
-     * @var ConfigInterface
+     * @var string
      */
-    private $config;
+    private $locale;
 
     /**
-     * @param ConfigInterface $config
+     * @param string $locale
      */
-    public function __construct(ConfigInterface $config)
+    public function __construct(string $locale = Factory::DEFAULT_LOCALE)
     {
-        $this->config = $config;
+        $this->locale = $locale;
     }
 
     /**
@@ -36,10 +36,35 @@ class FakerService
     public function getGenerator(): Generator
     {
         if ($this->generator === null) {
-            $locale = $this->config->get('faker', [])['locale'] ?? Factory::DEFAULT_LOCALE;
-            $this->generator = Factory::create($locale);
+            $this->generator = Factory::create($this->locale);
         }
 
         return $this->generator;
+    }
+
+    /**
+     * Get the current locale.
+     *
+     * @return string
+     */
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    /**
+     * Set the current locale.
+     *
+     * @param string $locale
+     * @return $this
+     */
+    public function setLocale(string $locale): self
+    {
+        if ($this->locale !== $locale) {
+            $this->locale = $locale;
+            $this->generator = null;
+        }
+
+        return $this;
     }
 }

--- a/src/Phar/Compiler.php
+++ b/src/Phar/Compiler.php
@@ -20,17 +20,17 @@ class Compiler
     private $basePath;
 
     /**
-     * @var string
+     * @var string[]
      */
-    private $locale;
+    private $locales;
 
     /**
-     * @param string $locale
+     * @param string[] $locales
      */
-    public function __construct(string $locale)
+    public function __construct(array $locales)
     {
         $this->basePath = dirname(dirname(__DIR__));
-        $this->locale = $locale;
+        $this->locales = $locales;
     }
 
     /**
@@ -108,7 +108,7 @@ class Compiler
                     [
                         'bin/',
                         'justinrainbow/json-schema/demo/',
-                        '#fakerphp/faker/src/Faker/Provider/(?!' . $this->locale . ')[a-zA-Z_]+/#',
+                        '#fakerphp/faker/src/Faker/Provider/(?!' . implode('|', $this->locales) . ')[a-zA-Z_]+/#',
                     ]
                 ),
             $this->createFinder($this->basePath . '/app')

--- a/tests/functional/Dumper/SqlDumperTest.php
+++ b/tests/functional/Dumper/SqlDumperTest.php
@@ -6,6 +6,7 @@ namespace Smile\GdprDump\Tests\Functional\Dumper;
 
 use Smile\GdprDump\Config\Config;
 use Smile\GdprDump\Dumper\SqlDumper;
+use Smile\GdprDump\Faker\FakerService;
 use Smile\GdprDump\Tests\Functional\TestCase;
 
 class SqlDumperTest extends TestCase
@@ -44,9 +45,16 @@ class SqlDumperTest extends TestCase
             unlink($this->dumpFile);
         }
 
+        /** @var FakerService $faker */
+        $faker = $this->getContainer()->get('faker.service');
+        $this->assertSame('en_US', $faker->getLocale());
+
         // Create the dump
         $dumper->dump($config);
         $this->assertDumpIsValid();
+
+        // Assert that the faker locale was changed
+        $this->assertSame('fr_FR', $faker->getLocale());
     }
 
     /**

--- a/tests/functional/Resources/config/templates/test.yaml
+++ b/tests/functional/Resources/config/templates/test.yaml
@@ -9,6 +9,9 @@ database:
 dump:
     output: 'php://stdout'
 
+faker:
+    locale: 'fr_FR'
+
 variables:
     main_store_id: 'select store_id from stores where code = "store1"'
 

--- a/tests/functional/TestCase.php
+++ b/tests/functional/TestCase.php
@@ -9,8 +9,8 @@ use RuntimeException;
 use Smile\GdprDump\AppKernel;
 use Smile\GdprDump\Config\Config;
 use Smile\GdprDump\Config\Loader\ConfigLoader;
+use Smile\GdprDump\Database\Config as DatabaseConfig;
 use Smile\GdprDump\Database\Database;
-use Smile\GdprDump\Dumper\Config\DatabaseConfig;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class TestCase extends BaseTestCase

--- a/tests/unit/Converter/ConverterFactoryTest.php
+++ b/tests/unit/Converter/ConverterFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Smile\GdprDump\Tests\Unit\Converter;
 
 use RuntimeException;
+use Smile\GdprDump\Config\Config;
 use Smile\GdprDump\Converter\ConverterFactory;
 use Smile\GdprDump\Converter\ConverterResolver;
 use Smile\GdprDump\Converter\Proxy\Cache;
@@ -181,7 +182,7 @@ class ConverterFactoryTest extends TestCase
 
         return new ConverterFactory(
             $resolver,
-            new FakerService()
+            new FakerService($this->createMock(Config::class))
         );
     }
 }

--- a/tests/unit/Converter/ConverterFactoryTest.php
+++ b/tests/unit/Converter/ConverterFactoryTest.php
@@ -180,9 +180,6 @@ class ConverterFactoryTest extends TestCase
         $resolver = new ConverterResolver();
         $resolver->addPath('Smile\\GdprDump\\Converter\\', dirname(dirname(dirname(__DIR__))) . '/src/Converter');
 
-        return new ConverterFactory(
-            $resolver,
-            new FakerService($this->createMock(Config::class))
-        );
+        return new ConverterFactory($resolver, new FakerService());
     }
 }

--- a/tests/unit/Database/ConfigTest.php
+++ b/tests/unit/Database/ConfigTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Smile\GdprDump\Tests\Unit\Dumper\Config;
+namespace Smile\GdprDump\Tests\Unit\Database;
 
 use PDO;
-use Smile\GdprDump\Dumper\Config\DatabaseConfig;
+use Smile\GdprDump\Database\Config;
 use Smile\GdprDump\Tests\Unit\TestCase;
 use UnexpectedValueException;
 
-class DatabaseConfigTest extends TestCase
+class ConfigTest extends TestCase
 {
     /**
      * Test the getter methods.
@@ -27,7 +27,7 @@ class DatabaseConfigTest extends TestCase
             'driver_options' => [PDO::ATTR_TIMEOUT, 60],
         ];
 
-        $config = new DatabaseConfig($params);
+        $config = new Config($params);
 
         $this->assertSame($params['driver'], $config->getDriver());
         $this->assertSame($params['driver_options'], $config->getDriverOptions());
@@ -42,7 +42,7 @@ class DatabaseConfigTest extends TestCase
      */
     public function testDefaultValues(): void
     {
-        $config = new DatabaseConfig(['name' => 'test']);
+        $config = new Config(['name' => 'test']);
 
         $this->assertSame('pdo_mysql', $config->getDriver());
         $this->assertSame('test', $config->getConnectionParam('name'));
@@ -58,6 +58,6 @@ class DatabaseConfigTest extends TestCase
     public function testMissingDatabaseName(): void
     {
         $this->expectException(UnexpectedValueException::class);
-        new DatabaseConfig([]);
+        new Config([]);
     }
 }

--- a/tests/unit/Dumper/Config/DumperConfigTest.php
+++ b/tests/unit/Dumper/Config/DumperConfigTest.php
@@ -57,7 +57,7 @@ class DumperConfigTest extends TestCase
     }
 
     /**
-     * Test the dump settings.
+     * Test dump settings.
      */
     public function testDumpSettings(): void
     {
@@ -70,6 +70,18 @@ class DumperConfigTest extends TestCase
         $settings = $config->getDumpSettings();
         $this->assertArrayHasKey('hex_blob', $settings);
         $this->assertTrue($settings['hex_blob']);
+    }
+
+    /**
+     * Test faker settings.
+     */
+    public function testFakerSettings(): void
+    {
+        $config = $this->createConfig(['faker' => ['locale' => 'en_US']]);
+
+        $settings = $config->getFakerSettings();
+        $this->assertArrayHasKey('locale', $settings);
+        $this->assertSame('en_US', $settings['locale']);
     }
 
     /**
@@ -102,9 +114,16 @@ class DumperConfigTest extends TestCase
 
         // Test these values because they differ from MySQLDump-PHP
         $settings = $config->getDumpSettings();
+        $this->assertArrayHasKey('add_drop_table', $settings);
         $this->assertTrue($settings['add_drop_table']);
+        $this->assertArrayHasKey('hex_blob', $settings);
         $this->assertFalse($settings['hex_blob']);
+        $this->assertArrayHasKey('lock_tables', $settings);
         $this->assertFalse($settings['lock_tables']);
+
+        $settings = $config->getFakerSettings();
+        $this->assertArrayHasKey('locale', $settings);
+        $this->assertSame(null, $settings['locale']);
     }
 
     /**

--- a/tests/unit/Faker/FakerServiceTest.php
+++ b/tests/unit/Faker/FakerServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Smile\GdprDump\Tests\Unit\Faker;
 
+use Smile\GdprDump\Config\Config;
 use Smile\GdprDump\Faker\FakerService;
 use Smile\GdprDump\Tests\Unit\TestCase;
 
@@ -14,7 +15,45 @@ class FakerServiceTest extends TestCase
      */
     public function testGenerator(): void
     {
-        $fakerService = new FakerService();
+        $fakerService = new FakerService($this->createMock(Config::class));
+
+        $generator = $fakerService->getGenerator();
+        $this->assertNotEmpty($generator->getProviders());
+    }
+
+    /**
+     * Test the "getGenerator" looks for the configured locale
+     */
+    public function testGeneratorUsesLocaleConfiguration(): void
+    {
+        $configMock = $this->createMock(Config::class);
+        $configMock
+            ->expects($this->once())
+            ->method('get')
+            ->with('faker')
+            ->willReturn(null);
+
+        $fakerService = new FakerService($configMock);
+
+        $generator = $fakerService->getGenerator();
+        $this->assertNotEmpty($generator->getProviders());
+    }
+
+    /**
+     * Test the "getGenerator" works with a locale configured
+     */
+    public function testGeneratorWithLocaleConfigured(): void
+    {
+        $configMock = $this->createMock(Config::class);
+        $configMock
+            ->expects($this->once())
+            ->method('get')
+            ->with('faker')
+            ->willReturn([
+                'locale' => 'de_DE'
+            ]);
+
+        $fakerService = new FakerService($configMock);
 
         $generator = $fakerService->getGenerator();
         $this->assertNotEmpty($generator->getProviders());

--- a/tests/unit/Faker/FakerServiceTest.php
+++ b/tests/unit/Faker/FakerServiceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Smile\GdprDump\Tests\Unit\Faker;
 
-use Smile\GdprDump\Config\Config;
+use Faker\Factory;
 use Smile\GdprDump\Faker\FakerService;
 use Smile\GdprDump\Tests\Unit\TestCase;
 
@@ -15,47 +15,23 @@ class FakerServiceTest extends TestCase
      */
     public function testGenerator(): void
     {
-        $fakerService = new FakerService($this->createMock(Config::class));
+        $fakerService = new FakerService();
 
         $generator = $fakerService->getGenerator();
         $this->assertNotEmpty($generator->getProviders());
+        $this->assertSame(Factory::DEFAULT_LOCALE, $fakerService->getLocale());
     }
 
     /**
-     * Test the "getGenerator" looks for the configured locale
+     * Test the "getGenerator" method with a custom locale.
      */
-    public function testGeneratorUsesLocaleConfiguration(): void
+    public function testGeneratorWithCustomLocale(): void
     {
-        $configMock = $this->createMock(Config::class);
-        $configMock
-            ->expects($this->once())
-            ->method('get')
-            ->with('faker')
-            ->willReturn(null);
-
-        $fakerService = new FakerService($configMock);
-
+        $fakerService = new FakerService();
         $generator = $fakerService->getGenerator();
-        $this->assertNotEmpty($generator->getProviders());
-    }
 
-    /**
-     * Test the "getGenerator" works with a locale configured
-     */
-    public function testGeneratorWithLocaleConfigured(): void
-    {
-        $configMock = $this->createMock(Config::class);
-        $configMock
-            ->expects($this->once())
-            ->method('get')
-            ->with('faker')
-            ->willReturn([
-                'locale' => 'de_DE'
-            ]);
-
-        $fakerService = new FakerService($configMock);
-
-        $generator = $fakerService->getGenerator();
-        $this->assertNotEmpty($generator->getProviders());
+        $fakerService->setLocale('ru_RU');
+        $this->assertSame('ru_RU', $fakerService->getLocale());
+        $this->assertNotSame($generator, $fakerService->getGenerator());
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your pull request fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Smile-SA/gdpr-dump/blob/master/CONTRIBUTING.md.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The faker converters always use `en_US` as default locale.

Issue Number: N/A

## What is the new behavior?
The faker locale can be configured in the dump configuration. It still defaults to `en_US`, but the locale *can* be configured.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
