### PR TITLE
Allow expressions in filter columns

### DIFF
--- a/app/config/example.yaml
+++ b/app/config/example.yaml
@@ -27,6 +27,11 @@ tables:
         filters:
             - ['created_at', 'gt', 'expr: date_sub(now(), interval 60 day)']
 
+    # Dump only CMS pages without "FAQ" in their meta title
+    cms_page:
+        filters:
+            - ["expr: COALESCE(meta_title, '')", 'notLike', '%FAQ%']
+
     # Anonymize a table named "my_custom_table"
     my_custom_table:
         converters:

--- a/src/Dumper/Mysql/TableFilterExtension.php
+++ b/src/Dumper/Mysql/TableFilterExtension.php
@@ -205,7 +205,7 @@ class TableFilterExtension implements ExtensionInterface
 
             $whereExpr = call_user_func_array(
                 $callable,
-                [$this->connection->quoteIdentifier($filter->getColumn()), $value]
+                [$this->getFilterColumn($filter), $value]
             );
 
             $queryBuilder->andWhere($whereExpr);
@@ -302,5 +302,17 @@ class TableFilterExtension implements ExtensionInterface
         }
 
         return $value;
+    }
+
+    /**
+     * Get a filter column so it can be safely injected in SQL query
+     * Extracts a possible expression to use instead of a real column name.
+     */
+    private function getFilterColumn(Filter $filter): mixed
+    {
+        $column = $filter->getColumn();
+
+        return str_starts_with($column, 'expr:') ?
+            ltrim(substr($column, 5)) : $this->connection->quoteIdentifier($column);
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your pull request fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/Smile-SA/gdpr-dump/blob/main/CONTRIBUTING.md.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added / updated (for bug fixes / features).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
The current behavior: the table filters are constructed which before this PR only allow a scalar, i.e. actual column value (as first argument).
This does not allow to build a condition where the subject/column is actually an expression.

## What is the new behavior?
<!-- Please describe the new behavior introduced by your changes. -->
As for the filter value, allows using the syntax 'expr: [My SQL expression]' as a filter column, for instance
```
my_table:
    filters:
       - ["expr: COALESCE(foo, '')", 'notLike', '%bar%']
```
if you wish to exclude the rows of `my_table` where the `foo` column contains 'bar' but also keep the rows where `foo` is null.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
```
[ ] Yes
[X] No
```

## Other information
<!-- Add any other context here. -->

Due to the way the filters interpretation is done, I was not able to add a specific unit test.
