### PR TITLE
Use the php tokenizer to validate converter conditions

### DIFF
--- a/tests/unit/Converter/ConditionBuilderTest.php
+++ b/tests/unit/Converter/ConditionBuilderTest.php
@@ -27,6 +27,16 @@ class ConditionBuilderTest extends TestCase
     }
 
     /**
+     * Assert that using an allowed function does not result in a thrown exception.
+     */
+    public function testAllowedFunctions(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $builder = new ConditionBuilder();
+        $builder->build('strpos({{email}}, "@acme.fr") !== false');
+    }
+
+    /**
      * Assert that an exception is thrown when an empty condition is specified.
      */
     public function testErrorOnEmptyCondition(): void
@@ -67,6 +77,26 @@ class ConditionBuilderTest extends TestCase
     }
 
     /**
+     * Assert that an exception is thrown when the condition contains a forbidden function.
+     */
+    public function testErrorOnForbiddenFunction(): void
+    {
+        $builder = new ConditionBuilder();
+        $this->expectException(RuntimeException::class);
+        $builder->build('usleep(1000)');
+    }
+
+    /**
+     * Assert that an exception is thrown when the condition contains a forbidden function enclosed in quotes.
+     */
+    public function testErrorOnForbiddenStringFunction(): void
+    {
+        $builder = new ConditionBuilder();
+        $this->expectException(RuntimeException::class);
+        $builder->build('\'usleep\'(1000)');
+    }
+
+    /**
      * Assert that an exception is thrown when the condition contains a static function call.
      */
     public function testErrorOnStaticFunction(): void
@@ -77,12 +107,12 @@ class ConditionBuilderTest extends TestCase
     }
 
     /**
-     * Assert that an exception is thrown when the condition contains a forbidden function.
+     * Assert that an exception is thrown when the condition contains a static function call enclosed in quotes.
      */
-    public function testErrorOnBlacklistedFunction(): void
+    public function testErrorOnStringStaticFunction(): void
     {
         $builder = new ConditionBuilder();
         $this->expectException(RuntimeException::class);
-        $builder->build('usleep(1000)');
+        $builder->build('\'ArrayHelper\'::getPath(\'id\') === 1');
     }
 }


### PR DESCRIPTION
Currently, conditions are validated with regular expressions, which is not safe and can also result in false positives.

This PR uses the php tokenizer to parse the condition and make sure it is valid.