### PR TITLE
Add `where` parameter and deprecate `filters` parameter

### DIFF
--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -239,6 +239,9 @@
                 "skip_conversion_if": {
                     "type": ["string", "number"]
                 },
+                "where": {
+                    "type": ["string"]
+                },
                 "filters": {
                     "type": "array",
                     "items": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -105,15 +105,8 @@
             <property name="linesCountBetweenDescriptionAndAnnotations" value="1"/>
             <property name="linesCountBetweenAnnotationsGroups" value="1"/>
             <property name="annotationsGroups" type="array">
-                <element value="
-                        @internal,
-                        @deprecated,
-                    "/>
-                <element value="
-                        @param\,
-                        @return\,
-                        @throws\,
-                    "/>
+                <element value="@inheritdoc"/>
+                <element value="@internal,@deprecated,@var,@param,@return,@throws"/>
             </property>
         </properties>
     </rule>

--- a/src/Converter/Anonymizer/AnonymizeDate.php
+++ b/src/Converter/Anonymizer/AnonymizeDate.php
@@ -29,6 +29,7 @@ class AnonymizeDate implements ConverterInterface
 
     /**
      * @inheritdoc
+     *
      * @throws UnexpectedValueException
      */
     public function convert(mixed $value, array $context = []): string

--- a/src/Dumper/Config/Table/Filter/Filter.php
+++ b/src/Dumper/Config/Table/Filter/Filter.php
@@ -6,6 +6,9 @@ namespace Smile\GdprDump\Dumper\Config\Table\Filter;
 
 use UnexpectedValueException;
 
+/**
+ * @deprecated
+ */
 class Filter
 {
     public const OPERATOR_EQ = 'eq';

--- a/src/Dumper/Config/Validation/QueryValidator.php
+++ b/src/Dumper/Config/Validation/QueryValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Smile\GdprDump\Dumper\Config\Validation;
 
+use TheSeer\Tokenizer\TokenCollection;
 use TheSeer\Tokenizer\Tokenizer;
 
 class QueryValidator
@@ -13,37 +14,75 @@ class QueryValidator
     /**
      * @var string[]
      */
-    private array $statementBlacklist = [
-        'grant', 'revoke', 'create', 'alter', 'drop', 'rename',
-        'insert', 'update', 'delete', 'truncate', 'replace',
-        'prepare', 'execute', 'lock', 'unlock', 'optimize', 'repair',
+    private array $statements = [
+        'alter', 'analyse', 'backup', 'binlog', 'cache', 'change', 'close', 'commit', 'create',
+        'deallocate', 'declare', 'delete', 'describe', 'drop', 'execute', 'explain', 'fetch', 'flush',
+        'get', 'grant', 'help', 'install', 'kill', 'load', 'lock', 'open', 'optimize', 'prepare',
+        'purge', 'rename', 'repair', 'reset', 'resignal', 'revoke', 'rollback', 'savepoint', 'select',
+        'set', 'password', 'show', 'shutdown', 'signal', 'start', 'truncate', 'uninstall', 'unlock',
+        'update', 'use', 'xa',
     ];
 
     /**
-     * Create the query validator.
+     * @var string[]
      */
-    public function __construct()
+    private array $allowedStatements;
+
+    /**
+     * @param string[] $allowedStatements
+     */
+    public function __construct(array $allowedStatements)
     {
         $this->tokenizer = new Tokenizer();
+
+        // Better performance to check array keys
+        $this->statements = array_flip($this->statements);
+        $this->allowedStatements = array_flip($allowedStatements);
     }
 
     /**
-     * Validate that a SQL query is safe for execution.
-     *
-     * @throws ValidationException
+     * Validate the query. An optional callback can be passed for additional validation.
      */
-    public function validate(string $query): void
+    public function validate(string $query, ?callable $callback = null): void
     {
-        // Use a PHP tokenizer to split the query into tokens
-        $tokens = $this->tokenizer->parse('<?php ' . strtolower($query) . '?>');
+        $tokens = $this->tokenize($query);
 
         foreach ($tokens as $token) {
-            // If the token is a word, check if it contains a forbidden statement
-            if ($token->getName() === 'T_STRING' && in_array($token->getValue(), $this->statementBlacklist, true)) {
-                $message = 'The following query contains a forbidden keyword: "%s". '
-                    . 'You may use "`%s`" to prevent this error.';
-                throw new ValidationException(sprintf($message, $query, $token->getValue()));
+            $name = $token->getName();
+            $value = $token->getValue();
+
+            if ($name === 'T_DEC' || $name === 'T_COMMENT') {
+                throw new ValidationException(sprintf('Forbidden comment found in query "%s".', $query));
+            }
+
+            if ($name === 'T_STRING' && !$this->isStatementAllowed($value)) {
+                throw new ValidationException(sprintf('Forbidden keyword "%s" found in query "%s".', $value, $query));
+            }
+
+            if ($callback !== null) {
+                $callback($token);
             }
         }
+    }
+
+    /**
+     * Tokenize the query.
+     */
+    private function tokenize(string $query): TokenCollection
+    {
+        return $this->tokenizer->parse('<?php ' . strtolower($query) . '?>');
+    }
+
+    /**
+     * Check whether the statement is allowed.
+     */
+    private function isStatementAllowed(string $statement): bool
+    {
+        if (empty($this->allowedStatements)) {
+            return !array_key_exists($statement, $this->statements);
+        }
+
+        return array_key_exists($statement, $this->allowedStatements)
+            || !array_key_exists($statement, $this->statements);
     }
 }

--- a/src/Dumper/Config/Validation/WhereExprValidator.php
+++ b/src/Dumper/Config/Validation/WhereExprValidator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Dumper\Config\Validation;
+
+use TheSeer\Tokenizer\Token;
+
+class WhereExprValidator
+{
+    private QueryValidator $queryValidator;
+
+    public function __construct()
+    {
+        $this->queryValidator = new QueryValidator(['select']);
+    }
+
+    /**
+     * Validate the where expression.
+     */
+    public function validate(string $expr): void
+    {
+        $openedBrackets = 0;
+
+        $this->queryValidator->validate($expr, function (Token $token) use ($expr, &$openedBrackets): void {
+            // Disallow using a closing bracket if there is no matching opening bracket -> prevents SQL injection
+            if ($token->getName() === 'T_OPEN_BRACKET') {
+                ++$openedBrackets;
+                return;
+            }
+
+            if ($token->getName() === 'T_CLOSE_BRACKET') {
+                if ($openedBrackets === 0) {
+                    throw new ValidationException(sprintf('Unmatched closing bracket found in query "%s".', $expr));
+                }
+
+                --$openedBrackets;
+            }
+        });
+    }
+}

--- a/tests/functional/Resources/config/templates/test.yaml
+++ b/tests/functional/Resources/config/templates/test.yaml
@@ -26,9 +26,7 @@ tables:
             - ['store_id', 'in', [1, 2]]
 
     customers:
-        filters:
-            - ['email', 'like', '%@test.org']
-            - ['created_at', 'gt', 'expr: date_sub(now(), interval 55 day)']
+        where: 'email like "%@test.org" and created_at > date_sub(now(), interval 55 day)'
         converters:
             email:
                 converter: 'prependText'

--- a/tests/unit/Dumper/Config/Table/TableConfigTest.php
+++ b/tests/unit/Dumper/Config/Table/TableConfigTest.php
@@ -6,6 +6,7 @@ namespace Smile\GdprDump\Tests\Unit\Dumper\Config\Table;
 
 use Smile\GdprDump\Dumper\Config\Table\Filter\Filter;
 use Smile\GdprDump\Dumper\Config\Table\TableConfig;
+use Smile\GdprDump\Dumper\Config\Validation\ValidationException;
 use Smile\GdprDump\Tests\Unit\TestCase;
 use UnexpectedValueException;
 
@@ -75,7 +76,45 @@ class TableConfigTest extends TestCase
     }
 
     /**
-     * Test the "filter" parameter.
+     * Test the "where" parameter.
+     */
+    public function testWhereCondition(): void
+    {
+        $condition = 'customer_id = 1';
+        $config = new TableConfig('table1', [
+            'where' => $condition,
+        ]);
+
+        $this->assertSame($condition, $config->getWhereCondition());
+        $this->assertTrue($config->hasWhereCondition());
+    }
+
+    /**
+     * Assert that an exception is thrown when a where condition contains disallowed statements.
+     */
+    public function testWhereConditionWithDisallowedStatement(): void
+    {
+        $this->expectException(ValidationException::class);
+        new TableConfig('table1', [
+            'where' => 'drop database example',
+        ]);
+    }
+
+    /**
+     * Assert that an exception is thrown when a where condition is terminated early.
+     */
+    public function testWhereConditionWithUnmatchedClosingBracket(): void
+    {
+        $this->expectException(ValidationException::class);
+        new TableConfig('table1', [
+            'where' => '1); select * from customer where (1',
+        ]);
+    }
+
+    /**
+     * Test the "filters" parameter.
+     *
+     * @deprecated
      */
     public function testFilter(): void
     {

--- a/tests/unit/Dumper/Config/Validation/QueryValidatorTest.php
+++ b/tests/unit/Dumper/Config/Validation/QueryValidatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Tests\Unit\Dumper\Config\Validation;
+
+use RuntimeException;
+use Smile\GdprDump\Dumper\Config\Validation\QueryValidator;
+use Smile\GdprDump\Dumper\Config\Validation\ValidationException;
+use Smile\GdprDump\Tests\Unit\TestCase;
+use TheSeer\Tokenizer\Token;
+
+class QueryValidatorTest extends TestCase
+{
+    /**
+     * Assert that no exceptio is thrown when the query is valid.
+     */
+    public function testAllowedStatement(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $queryValidator = new QueryValidator(['select']);
+        $queryValidator->validate('select * from my_table');
+    }
+
+    /**
+     * Assert that an exception is thrown when using a forbidden statement.
+     */
+    public function testForbiddenStatement(): void
+    {
+        $this->expectException(ValidationException::class);
+        $queryValidator = new QueryValidator(['set']);
+        $queryValidator->validate('select * from my_table');
+    }
+
+    /**
+     * Assert that the query validator is case insensitive.
+     */
+    public function testIsCaseInsensitive(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $queryValidator = new QueryValidator(['select']);
+        $queryValidator->validate('SELECT * from my_table');
+    }
+
+    /**
+     * Assert that the validation callback parameter is working properly.
+     */
+    public function testValidationCallback(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $queryValidator = new QueryValidator(['select']);
+        $queryValidator->validate('select * from my_table', function (Token $token): void {
+            throw new RuntimeException($token->getValue());
+        });
+    }
+}

--- a/tests/unit/Dumper/Config/Validation/WhereExprValidatorTest.php
+++ b/tests/unit/Dumper/Config/Validation/WhereExprValidatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Tests\Unit\Dumper\Config\Validation;
+
+use Smile\GdprDump\Dumper\Config\Validation\ValidationException;
+use Smile\GdprDump\Dumper\Config\Validation\WhereExprValidator;
+use Smile\GdprDump\Tests\Unit\TestCase;
+
+class WhereExprValidatorTest extends TestCase
+{
+    /**
+     * Assert that no exception is thrown when the expression is valid.
+     */
+    public function testValidExpression(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $queryValidator = new WhereExprValidator();
+        $queryValidator->validate('email like "%@test.org" and created_at > date_sub(now(), interval 55 day)');
+    }
+
+    /**
+     * Assert that no exception is thrown if the query includes a sub select.
+     */
+    public function testSubSelectIsAllowed(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $queryValidator = new WhereExprValidator();
+        $queryValidator->validate('order_id in (select entity_id from order where status = "closed")');
+    }
+
+    /**
+     * Assert that an exception is thrown when using a forbidden statement.
+     */
+    public function testForbiddenStatement(): void
+    {
+        $this->expectException(ValidationException::class);
+        $queryValidator = new WhereExprValidator();
+        $queryValidator->validate('drop database example');
+    }
+
+    /**
+     * Assert that an exception is thrown if the query is terminated early.
+     */
+    public function testUnmatchedClosingBracket(): void
+    {
+        $this->expectException(ValidationException::class);
+        $queryValidator = new WhereExprValidator();
+        $queryValidator->validate('1); select * from customer where (1');
+    }
+}


### PR DESCRIPTION
New filter syntax:

```yaml
tables:
    customer:
        where: 'email like "%@test.org" or created_at > date_sub(now(), interval 55 day)'
```

A query validator is making sure that the query does not include any dangerous statement (execute, drop, alter...).

The PR deprecates the `filters` param.
This param is restrictive, and it already allows to inject raw SQL in some way (with `expr:` syntax), so it's barely more secure than a plain where.
