### PR TITLE
Use a readonly connection to create the dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## WIP
+
+- Use a readonly connection to create the dump ([#121](https://github.com/Smile-SA/gdpr-dump/pull/121))
+
 ## [4.2.0] - 2024-03-05
 [4.2.0]: https://github.com/Smile-SA/gdpr-dump/compare/4.1.1...4.2.0
 

--- a/src/Dumper/MysqlDumper.php
+++ b/src/Dumper/MysqlDumper.php
@@ -90,6 +90,9 @@ class MysqlDumper implements DumperInterface
         $settings['exclude-tables'] = $config->getTablesBlacklist();
         $settings['no-data'] = $config->getTablesToTruncate();
 
+        // Set readonly session
+        $settings['init_commands'][] = 'SET SESSION TRANSACTION READ ONLY';
+
         return $settings;
     }
 }


### PR DESCRIPTION
This PR adds the following query to the `init_commands` array passed to mysqldump-php:
`SET SESSION TRANSACTION READ ONLY`