### PR TITLE
Use strict types in schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## 5.0.0 (WIP)
 
+Breaking changes:
+
 - Added table column validation. GdprDump now throws an exception if a config file contains an undefined column ([#125](https://github.com/Smile-SA/gdpr-dump/pull/125))
 - Removed support of the `filters` parameter. Use the `where` parameter instead ([#128](https://github.com/Smile-SA/gdpr-dump/pull/128))
 - Removed undefined column customer_address.vat_id from shopware6 template ([#132](https://github.com/Smile-SA/gdpr-dump/pull/132))
+- Stricter config file validation: string parameters don't accept integer values anymore ([#129](https://github.com/Smile-SA/gdpr-dump/pull/129))
 
 ## [4.2.2] - 2024-03-26
 [4.2.2]: https://github.com/Smile-SA/gdpr-dump/compare/4.2.1...4.2.2

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -8,7 +8,7 @@
             "type": "boolean"
         },
         "version": {
-            "type":  ["string", "number"]
+            "type": "string"
         },
         "if_version": {
             "type": "object",
@@ -43,14 +43,14 @@
         "tables_whitelist": {
             "type": "array",
             "items": {
-                "type": ["string", "number"],
+                "type": "string",
                 "minLength": 1
             }
         },
         "tables_blacklist": {
             "type": "array",
             "items": {
-                "type": ["string", "number"],
+                "type": "string",
                 "minLength": 1
             }
         }
@@ -84,30 +84,29 @@
                     }
                 },
                 "host": {
-                    "type": ["string", "number"],
+                    "type": "string",
                     "minLength": 1
                 },
                 "port": {
-                    "type": ["string", "integer"],
-                    "minLength": 1
+                    "type": "integer"
                 },
                 "user": {
-                    "type": ["string", "number"],
+                    "type": "string",
                     "minLength": 1
                 },
                 "password": {
-                    "type": ["string", "number"]
+                    "type": "string"
                 },
                 "name": {
-                    "type": ["string", "number"],
+                    "type": "string",
                     "minLength": 1
                 },
                 "charset": {
-                    "type": ["string", "number"],
+                    "type": "string",
                     "minLength": 1
                 },
                 "unix_socket": {
-                    "type": ["string", "number"],
+                    "type": "string",
                     "minLength": 1
                 }
             },
@@ -117,7 +116,7 @@
             "type": "object",
             "properties": {
                 "output": {
-                    "type": ["string", "number"],
+                    "type": "string",
                     "minLength": 1
                 },
                 "add_drop_database": {
@@ -237,16 +236,16 @@
                     }
                 },
                 "skip_conversion_if": {
-                    "type": ["string", "number"]
+                    "type": "string"
                 },
                 "where": {
-                    "type": ["string"]
+                    "type": "string"
                 },
                 "filters": {
                     "deprecated": true
                 },
                 "order_by": {
-                    "type": ["string", "number"]
+                    "type": "string"
                 },
                 "limit": {
                     "type": ["integer", "null"]
@@ -255,7 +254,7 @@
             "additionalProperties": false
         },
         "converter": {
-            "type": ["object"],
+            "type": "object",
             "properties": {
                 "converter": {
                     "type": "string",
@@ -292,13 +291,13 @@
                     }
                 },
                 "condition": {
-                    "type": ["string", "number"]
+                    "type": "string"
                 },
                 "unique": {
                     "type": "boolean"
                 },
                 "cache_key": {
-                    "type": ["string", "number"]
+                    "type": "string"
                 },
                 "disabled": {
                     "type": "boolean"

--- a/tests/functional/Config/Validator/JsonSchemaValidatorTest.php
+++ b/tests/functional/Config/Validator/JsonSchemaValidatorTest.php
@@ -33,7 +33,7 @@ class JsonSchemaValidatorTest extends TestCase
                 'user' => 'myuser',
                 'password' => 'mypassword',
                 'host' => 'myhost',
-                'port' => '3306',
+                'port' => 3306,
                 'driver' => 'pdo_mysql',
                 'charset' => 'utf8mb',
                 'driver_options' => [


### PR DESCRIPTION
Currently, the schema file that is used to validate the config file is very permissive.

For example, most parameters that are supposed to be strings accept integer values:

```yaml
tables_whitelist:
    - 0 # this is considered valid
```

This PR changes all string parameters to accept only string values.

This is a breaking change, this feature will be released in 5.0.0.