### PR TITLE
Fixed magento2.yaml: Field that random email was generated for, was actually a smallint

### DIFF
--- a/app/config/templates/magento2.yaml
+++ b/app/config/templates/magento2.yaml
@@ -106,7 +106,7 @@ tables:
             email:
                 converter: 'randomizeEmail'
             dob:
-                converter: 'anonymizeDateTime'
+                converter: 'randomizeDate'
             shipping_full:
                 converter: 'randomizeText'
             billing_full:

--- a/app/config/templates/magento2.yaml
+++ b/app/config/templates/magento2.yaml
@@ -593,8 +593,6 @@ if_version:
                 converters:
                     email:
                         converter: 'randomizeEmail'
-                    email_imported:
-                        converter: 'randomizeEmail'
 
             email_sms_order_queue:
                 converters:

--- a/app/config/templates/magento2.yaml
+++ b/app/config/templates/magento2.yaml
@@ -106,7 +106,7 @@ tables:
             email:
                 converter: 'randomizeEmail'
             dob:
-                converter: 'anonymizeDate'
+                converter: 'anonymizeDateTime'
             shipping_full:
                 converter: 'randomizeText'
             billing_full:

--- a/app/config/templates/magento2.yaml
+++ b/app/config/templates/magento2.yaml
@@ -106,7 +106,7 @@ tables:
             email:
                 converter: 'randomizeEmail'
             dob:
-                converter: 'randomizeDate'
+                converter: 'anonymizeDate'
             shipping_full:
                 converter: 'randomizeText'
             billing_full:


### PR DESCRIPTION
## PR Checklist

Please check if your pull request fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Smile-SA/gdpr-dump/blob/main/CONTRIBUTING.md.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It tries to run `randomizeEmail` on the `email_imported` field in the `email_contact` table. `email_imported` is a SMALLINT field, so this results in exported SQL that cannot be imported. We recieved the following error during one of these imports.

```
[feature-branch]   Import MySQL Database
[feature-branch] Importing SQL dump /home/***.sql.gz to database ***
[feature-branch] ERROR 1054 (42S22) at line 12169: Unknown column '8k9' in 'field list'
[feature-branch] gzip: stdout: Broken pipe
[feature-branch] Finished
```

`8k9` in this case turned out to be the random email it tried to generate:

```
--
-- Dumping data for table `email_contact`
--

LOCK TABLES `email_contact` WRITE;
/*!40000 ALTER TABLE `email_contact` DISABLE KEYS */;
SET autocommit=0;
INSERT INTO `email_contact` VALUES (1,NULL,NULL,0,0,0,'',NULL,NULL,8k9,0,NULL,NULL);
/*!40000 ALTER TABLE `email_contact` ENABLE KEYS */;
UNLOCK TABLES;
COMMIT;
```

I think this is happening because in https://github.com/Smile-SA/gdpr-dump/pull/141/files, the table name that the columns that **was** supposed to be randomized, was removed, but not the field.

Issue Number: N/A

## What is the new behavior?
Because I removed the field from the default magento2.yaml config, it no longer tries to put a random string in the smallint field, resulting in a backup that we can import successfully.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
```
[ ] Yes
[x] No
```

## Other information
<!-- Add any other context here. -->
