### PR TITLE
Add strict mode

### DIFF
--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -4,6 +4,9 @@
         "extends": {
             "type": ["string", "array"]
         },
+        "strict_schema": {
+            "type": "boolean"
+        },
         "requires_version": {
             "type": "boolean"
         },

--- a/tests/functional/Dumper/Config/ConfigProcessorTest.php
+++ b/tests/functional/Dumper/Config/ConfigProcessorTest.php
@@ -24,8 +24,7 @@ final class ConfigProcessorTest extends TestCase
             ],
         ]);
 
-        $processor = $this->createConfigProcessor();
-        $processor->process($config);
+        $this->createConfigProcessor()->process($config);
 
         // Assert that table names were resolved
         $this->assertSame(['stores'], $config->get('tables_blacklist'));

--- a/tests/functional/Resources/config/templates/config.yaml
+++ b/tests/functional/Resources/config/templates/config.yaml
@@ -1,6 +1,6 @@
 ---
-version: '2.2.0'
 extends: 'template.yaml'
+version: '2.2.0'
 
 database:
     host: '%env(DB_HOST)%'

--- a/tests/unit/Dumper/Config/ConfigProcessorTest.php
+++ b/tests/unit/Dumper/Config/ConfigProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Smile\GdprDump\Tests\Unit\Dumper\Config;
 
+use RuntimeException;
 use Smile\GdprDump\Config\Config;
 use Smile\GdprDump\Database\Metadata\MetadataInterface;
 use Smile\GdprDump\Dumper\Config\ConfigProcessor;
@@ -22,8 +23,7 @@ final class ConfigProcessorTest extends TestCase
             'tables' => ['table3' => ['truncate' => true], 'not_exists' => ['truncate' => true]],
         ]);
 
-        $processor = $this->createConfigProcessor();
-        $processor->process($config);
+        $this->createConfigProcessor()->process($config);
 
         // Assert that table names were resolved
         $this->assertSame(['table1'], $config->get('tables_blacklist'));
@@ -43,8 +43,7 @@ final class ConfigProcessorTest extends TestCase
             'tables' => ['table*' => ['truncate' => true]],
         ]);
 
-        $processor = $this->createConfigProcessor();
-        $processor->process($config);
+        $this->createConfigProcessor()->process($config);
 
         // Assert that table names were resolved
         $this->assertSame(['table1', 'table2', 'table3'], $config->get('tables_blacklist'));
@@ -59,11 +58,75 @@ final class ConfigProcessorTest extends TestCase
     public function testProcessorWithEmptyConfig(): void
     {
         $config = new Config();
-        $processor = $this->createConfigProcessor();
-        $processor->process($config);
+        $this->createConfigProcessor()->process($config);
 
         // Assert that the config was not modified
         $this->assertSame([], $config->toArray());
+    }
+
+    /**
+     * Test the config processor with strict mode enabled.
+     */
+    public function testStrictMode(): void
+    {
+        $config = new Config([
+            'strict' => true,
+            'tables_blacklist' => ['table1'],
+            'tables_whitelist' => ['table2'],
+            'tables' => ['table*' => ['truncate' => true]],
+        ]);
+
+        $this->createConfigProcessor()->process($config);
+
+        $this->assertSame(['table1'], $config->get('tables_blacklist'));
+        $this->assertSame(['table2'], $config->get('tables_whitelist'));
+        $this->assertIsArray($config->get('tables'));
+        $this->assertSame(['table1', 'table2', 'table3'], array_keys($config->get('tables')));
+    }
+
+    /**
+     * Assert that an exception is thrown in strict mode when the table blacklist contains an invalid table name.
+     */
+    public function testStrictModeWithInvalidTableExclusion(): void
+    {
+        $config = new Config([
+            'strict_schema' => true,
+            'tables_blacklist' => ['table1', 'not_exists'],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No table found with pattern "not_exists".');
+        $this->createConfigProcessor()->process($config);
+    }
+
+    /**
+     * Assert that an exception is thrown in strict mode when the table whitelist contains an invalid table name.
+     */
+    public function testStrictModeWithInvalidTableInclusion(): void
+    {
+        $config = new Config([
+            'strict_schema' => true,
+            'tables_whitelist' => ['table2', 'not_exists'],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No table found with pattern "not_exists".');
+        $this->createConfigProcessor()->process($config);
+    }
+
+    /**
+     * Assert that an exception is thrown in strict mode when the tables config contains an invalid table.
+     */
+    public function testStrictModeWithInvalidTableConfig(): void
+    {
+        $config = new Config([
+            'strict_schema' => true,
+            'tables' => ['table3' => ['truncate' => true], 'not_exists' => ['truncate' => true]],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No table found with pattern "not_exists".');
+        $this->createConfigProcessor()->process($config);
     }
 
     /**


### PR DESCRIPTION
This PR adds a config parameter named `strict_schema` (`false` by default).

When strict mode is enabled, GdprDump displays an error message if the config file contains undefined tables.

To enable strict mode:

```yaml
strict_schema: true
```