### PR TITLE
Fixed an error that occurred when parsing table name patterns

### DIFF
--- a/src/Dumper/Config/ConfigProcessor.php
+++ b/src/Dumper/Config/ConfigProcessor.php
@@ -89,7 +89,7 @@ final class ConfigProcessor
 
             foreach ($matches as $match) {
                 // Throw an exception if a converter refers to a column that does not exist
-                $this->validateTableColumns($tableName, $tableData);
+                $this->validateTableColumns($match, $tableData);
 
                 // Merge table configuration
                 if (!array_key_exists($match, $resolved)) {


### PR DESCRIPTION
Fixes the following error:

```
In MysqlMetadata.php line 65:
                                                           
  [RuntimeException]                                       
  The table "log_*" is not defined. 
```