### PR TITLE
Enable strict mode by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 
 Breaking changes:
 
+- `strict_schema` is enabled by default (except in config templates such as `magento2`)
 - Fixed `if_version` parameter being processed too late ([#188](https://github.com/Smile-SA/gdpr-dump/pull/188))
 
 Improvements:

--- a/app/config/templates/drupal7.yaml
+++ b/app/config/templates/drupal7.yaml
@@ -1,3 +1,5 @@
+strict_schema: false
+
 tables:
     cache:
         truncate: true

--- a/app/config/templates/drupal8.yaml
+++ b/app/config/templates/drupal8.yaml
@@ -1,3 +1,5 @@
+strict_schema: false
+
 tables:
     cache_*:
         truncate: true

--- a/app/config/templates/magento1.yaml
+++ b/app/config/templates/magento1.yaml
@@ -1,3 +1,5 @@
+strict_schema: false
+
 variables:
     firstname_attribute_id: 'select attribute_id from eav_attribute where attribute_code = "firstname" and entity_type_id = 1'
     middlename_attribute_id: 'select attribute_id from eav_attribute where attribute_code = "middlename" and entity_type_id = 1'

--- a/app/config/templates/magento2.yaml
+++ b/app/config/templates/magento2.yaml
@@ -1,3 +1,5 @@
+strict_schema: false
+
 tables:
     admin_user_session:
         truncate: true

--- a/app/config/templates/oro4.yaml
+++ b/app/config/templates/oro4.yaml
@@ -1,3 +1,5 @@
+strict_schema: false
+
 tables:
     oro_logger_log_entry:
         truncate: true

--- a/app/config/templates/shopware6.yaml
+++ b/app/config/templates/shopware6.yaml
@@ -1,3 +1,5 @@
+strict_schema: false
+
 dump:
     hex_blob: true
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -15,7 +15,7 @@ use Smile\GdprDump\Configuration\Validator\QueryValidator;
  */
 final class Configuration
 {
-    private bool $strictSchema = false;
+    private bool $strictSchema = true;
     private DumpConfig $dumpConfig;
     private FilterPropagationConfig $filterPropagationConfig;
     private FakerConfig $fakerConfig;

--- a/tests/functional/Resources/config/config.yaml
+++ b/tests/functional/Resources/config/config.yaml
@@ -1,4 +1,5 @@
 extends: 'parent.yaml'
+strict_schema: false
 version: '2.2.0'
 
 database:

--- a/tests/unit/Configuration/ConfigurationTest.php
+++ b/tests/unit/Configuration/ConfigurationTest.php
@@ -58,7 +58,7 @@ final class ConfigurationTest extends TestCase
     public function testDefaultValues(): void
     {
         $configuration = new Configuration();
-        $this->assertFalse($configuration->isStrictSchema());
+        $this->assertTrue($configuration->isStrictSchema());
 
         // Assert that all arrays are empty
         $this->assertTrue($configuration->getTableConfigs()->isEmpty());

--- a/tests/unit/Dumper/Config/TableNameResolverTest.php
+++ b/tests/unit/Dumper/Config/TableNameResolverTest.php
@@ -20,18 +20,12 @@ final class TableNameResolverTest extends TestCase
     public function testTableNameResolution(): void
     {
         $configuration = (new Configuration())
-            ->setIncludedTables(['table1', 'not_exists'])
-            ->setExcludedTables(['table2', 'not_exists'])
-            ->setTableConfigs(
-                new TableConfigMap([
-                    'table3' => (new TableConfig())->setLimit(0),
-                    'not_exists' => new TableConfig(),
-                ])
-            );
+            ->setIncludedTables(['table1'])
+            ->setExcludedTables(['table2'])
+            ->setTableConfigs(new TableConfigMap(['table3' => (new TableConfig())->setLimit(0)]));
 
         $this->createResolver()->process($configuration);
 
-        // Assert that table names were resolved
         $this->assertSame(['table1'], $configuration->getIncludedTables());
         $this->assertSame(['table2'], $configuration->getExcludedTables());
 
@@ -162,18 +156,24 @@ final class TableNameResolverTest extends TestCase
     }
 
     /**
-     * Test the config processor with strict mode enabled.
+     * Test the config processor with strict mode disabled.
      */
-    public function testStrictMode(): void
+    public function testStrictModeDisabled(): void
     {
         $configuration = (new Configuration())
-            ->setStrictSchema(true)
-            ->setIncludedTables(['table1'])
-            ->setExcludedTables(['table2'])
-            ->setTableConfigs(new TableConfigMap(['table3' => (new TableConfig())->setLimit(0)]));
+            ->setStrictSchema(false)
+            ->setIncludedTables(['table1', 'not_exists'])
+            ->setExcludedTables(['table2', 'not_exists'])
+            ->setTableConfigs(
+                new TableConfigMap([
+                    'table3' => (new TableConfig())->setLimit(0),
+                    'not_exists' => new TableConfig(),
+                ])
+            );
 
         $this->createResolver()->process($configuration);
 
+        // Assert that table names were resolved
         $this->assertSame(['table1'], $configuration->getIncludedTables());
         $this->assertSame(['table2'], $configuration->getExcludedTables());
 
@@ -186,12 +186,11 @@ final class TableNameResolverTest extends TestCase
     }
 
     /**
-     * Assert that an exception is thrown in strict mode when the table whitelist contains an invalid table name.
+     * Assert that an exception is thrown when the table whitelist contains an invalid table name.
      */
-    public function testStrictModeWithInvalidTableInclusion(): void
+    public function testStrictInvalidTableInclusion(): void
     {
         $configuration = (new Configuration())
-            ->setStrictSchema(true)
             ->setIncludedTables(['table1', 'not_exists']);
 
         $this->expectException(MetadataException::class);
@@ -200,12 +199,11 @@ final class TableNameResolverTest extends TestCase
     }
 
     /**
-     * Assert that an exception is thrown in strict mode when the table blacklist contains an invalid table name.
+     * Assert that an exception is thrown when the table blacklist contains an invalid table name.
      */
     public function testStrictModeWithInvalidTableExclusion(): void
     {
         $configuration = (new Configuration())
-            ->setStrictSchema(true)
             ->setExcludedTables(['table2', 'not_exists']);
 
         $this->expectException(MetadataException::class);
@@ -214,12 +212,11 @@ final class TableNameResolverTest extends TestCase
     }
 
     /**
-     * Assert that an exception is thrown in strict mode when the tables config contains an invalid table.
+     * Assert that an exception is thrown when the tables config contains an invalid table.
      */
     public function testStrictModeWithInvalidTableConfig(): void
     {
         $configuration = (new Configuration())
-            ->setStrictSchema(true)
             ->setTableConfigs(
                 new TableConfigMap([
                     'table3' => new TableConfig(),


### PR DESCRIPTION
This PR enables the `strict_schema` option by default (except in config templates, e.g. `magento2`).

This is a breaking change.
When this mode is enabled, the dump creation fails if the configuration file contains undefined table names.
An error is also triggered if a pattern (e.g. `log_*`) does not match any existing table.

The default is still `false` in config templates because depending on the framework version and edition, some tables may or may not exist.