### PR TITLE
Add `converter_templates` config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 New features:
 
+- Added `converter_templates` config parameter ([#192](https://github.com/Smile-SA/gdpr-dump/pull/192))
 - Added `strict_schema` config parameter ([#158](https://github.com/Smile-SA/gdpr-dump/pull/158))
 - The configuration can be passed as a yaml or json string from stdin
 
@@ -15,13 +16,13 @@ Breaking changes:
 
 Improvements:
 
-- Upgraded `justinrainbow/json-schema` package to from v5 to v6 ([#185](https://github.com/Smile-SA/gdpr-dump/pull/185))
+- The command-line option `--password` now behaves in the same way as the mysqldump command
 - Performance improvement: the DI container is now dumped to a cache file ([#189](https://github.com/Smile-SA/gdpr-dump/pull/189))
+- Upgraded `justinrainbow/json-schema` package to from v5 to v6 ([#185](https://github.com/Smile-SA/gdpr-dump/pull/185))
 
-Other changes:
+Deprecations:
 
 - Deprecated config parameter `requires_version` ([#186](https://github.com/Smile-SA/gdpr-dump/pull/186))
-- The command-line option `--password` now behaves in the same way as the mysqldump command
 
 ## [5.0.5] - 2025-04-05
 [5.0.5]: https://github.com/Smile-SA/gdpr-dump/compare/5.0.4...5.0.5

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -52,6 +52,12 @@
             "additionalProperties": {
                 "$ref": "#/definitions/ifVersion"
             }
+        },
+        "converter_templates": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/converter"
+            }
         }
     },
     "additionalProperties": false,

--- a/src/Configuration/Compiler/Processor/ConverterTemplatesProcessor.php
+++ b/src/Configuration/Compiler/Processor/ConverterTemplatesProcessor.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Configuration\Compiler\Processor;
+
+use Smile\GdprDump\Configuration\Compiler\CompilerStep;
+use Smile\GdprDump\Configuration\Exception\ParseException;
+use Smile\GdprDump\Configuration\Loader\Container;
+use Smile\GdprDump\Util\Objects;
+use stdClass;
+
+class ConverterTemplatesProcessor implements Processor
+{
+    public function getStep(): CompilerStep
+    {
+        return CompilerStep::AFTER_VALIDATION;
+    }
+
+    /**
+     * Process the "converter_templates" parameter.
+     */
+    public function process(Container $container): void
+    {
+        $templates = $container->get('converter_templates');
+        if (!$templates) {
+            return;
+        }
+
+        foreach (get_object_vars($container->get('tables')) as $tableConfig) {
+            if (!property_exists($tableConfig, 'converters')) {
+                continue;
+            }
+
+            foreach (get_object_vars($tableConfig->converters) as $column => $converterConfig) {
+                $tableConfig->converters->{$column} = $this->applyTemplateToConverter($converterConfig, $templates);
+            }
+        }
+    }
+
+    /**
+     * Try to apply a converter template to the specified converter object.
+     */
+    private function applyTemplateToConverter(stdClass $converterConfig, stdClass $templates): stdClass
+    {
+        if (!property_exists($converterConfig, 'converter')) {
+            return $converterConfig; // not supposed to happen but better safe than sorry
+        }
+
+        // Apply template to parameters (e.g. the "chain" converter has a list of converters as one of its parameters)
+        $this->applyTemplateToParameters($converterConfig, $templates);
+
+        // Apply template to the converter itself
+        $candidateTemplate = $converterConfig->converter;
+        if (!property_exists($templates, $candidateTemplate)) {
+            return $converterConfig;
+        }
+
+        $templateCopy = Objects::deepClone($templates->{$candidateTemplate});
+        $converterName = $templateCopy->converter;
+        if (property_exists($templates, $converterName)) {
+            throw new ParseException('Nested converter templates are not supported.');
+        }
+
+        Objects::merge($templateCopy, $converterConfig);
+        $templateCopy->converter = $converterName;
+
+        return $templateCopy;
+    }
+
+    /**
+     * Try to apply a converter template to the parameters of the specified converter object.
+     */
+    private function applyTemplateToParameters(stdClass $converterConfig, stdClass $templates): void
+    {
+        if (!property_exists($converterConfig, 'parameters')) {
+            return;
+        }
+
+        $parameters = $converterConfig->parameters;
+
+        // "converters" parameter (type array)
+        if (property_exists($parameters, 'converters') && is_array($parameters->converters)) {
+            $parameters->converters = array_map(
+                fn (stdClass $item) => $this->applyTemplateToConverter($item, $templates),
+                $parameters->converters
+            );
+            return;
+        }
+
+        // "converters" parameter (type object)
+        if (property_exists($parameters, 'converters') && $parameters->converters instanceof stdClass) {
+            foreach (get_object_vars($parameters->converters) as $key => $value) {
+                $parameters->converters->{$key} = $this->applyTemplateToConverter($value, $templates);
+            }
+            return;
+        }
+
+        // "converter" parameter (type object)
+        if (property_exists($parameters, 'converter') && $parameters->converter instanceof stdClass) {
+            $parameters->converter = $this->applyTemplateToConverter(
+                $parameters->converter,
+                $templates
+            );
+        }
+    }
+}

--- a/src/Configuration/Mapper/ConfigurationMapper.php
+++ b/src/Configuration/Mapper/ConfigurationMapper.php
@@ -45,7 +45,7 @@ final class ConfigurationMapper
                 ),
                 'strict_schema' => $configuration->setStrictSchema($value),
                 'variables' => $configuration->setSqlVariables($value),
-                'version', 'if_version' => null, // only useful for parsing and validation
+                'version', 'if_version', 'converter_templates' => null, // only useful for parsing and validation
                 'requires_version' => null, // deprecated parameter
                 default => throw new UnexpectedValueException(sprintf('Unsupported config property "%s".', $key)),
             };

--- a/tests/unit/Configuration/Compiler/Processor/ConverterTemplatesProcessorTest.php
+++ b/tests/unit/Configuration/Compiler/Processor/ConverterTemplatesProcessorTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\GdprDump\Tests\Unit\Configuration\Compiler\Processor;
+
+use Smile\GdprDump\Configuration\Compiler\Processor\ConverterTemplatesProcessor;
+use Smile\GdprDump\Configuration\Exception\ParseException;
+use Smile\GdprDump\Configuration\Loader\Container;
+use Smile\GdprDump\Tests\Unit\TestCase;
+use Smile\GdprDump\Util\Objects;
+
+final class ConverterTemplatesProcessorTest extends TestCase
+{
+    /**
+     * Assert that converter templates are merged into the configuration.
+     */
+    public function testTemplatesMerged(): void
+    {
+        $container = new Container(
+            (object) [
+                'tables' => (object) [
+                    'no_converter' => (object) [
+                        'truncate' => true,
+                    ],
+                    'no_template' => (object) [
+                        'converters' => (object) [
+                            'email' => (object) [
+                                'converter' => 'randomizeEmail',
+                            ],
+                        ],
+                    ],
+                    'template' => (object) [
+                        'converters' => (object) [
+                            'email' => (object) [
+                                'converter' => 'uniqueEmail',
+                            ],
+                        ],
+                    ],
+                    'template_with_config' => (object) [
+                        'converters' => (object) [
+                            'email' => (object) [
+                                'converter' => 'uniqueEmail',
+                                'unique' => false,
+                                'parameters' => (object) [
+                                    'min_length' => 5,
+                                ],
+                            ],
+                        ],
+                    ],
+                    'converter_parameter' => (object) [
+                        'converters' => (object) [
+                            'username' => (object) [
+                                'converter' => 'cache',
+                                'parameters' => (object) [
+                                    'cache_key' => 'user',
+                                    'converter' => (object) ['converter' => 'uniqueUser'],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'converters_parameter_object' => (object) [
+                        'converters' => (object) [
+                            'chain' => (object) [
+                                'converter' => 'chain',
+                                'parameters' => (object) [
+                                    'converters' => (object) [
+                                        'username' => (object) ['converter' => 'uniqueUser'],
+                                        'fullname' => (object) ['converter' => 'randomizeText'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'converters_parameter_array' => (object) [
+                        'converters' => (object) [
+                            'chain' => (object) [
+                                'converter' => 'chain',
+                                'parameters' => (object) [
+                                    'converters' => [
+                                        (object) ['converter' => 'uniqueUser'],
+                                        (object) ['converter' => 'toLower'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'converter_templates' => (object) [
+                    'uniqueEmail' => (object) [
+                        'converter' => 'randomizeEmail',
+                        'unique' => true,
+                        'parameters' => (object) [
+                            'domains' => ['example.com'],
+                            'min_length' => 10,
+                        ],
+                    ],
+                    'uniqueUser' => (object) [
+                        'converter' => 'randomizeText',
+                        'unique' => true,
+                    ],
+                ],
+            ]
+        );
+
+        // Build the expected result (same configuration as above but with templates applied)
+        $expected = $container->toArray();
+        $expected['tables']['template']['converters']['email']['converter'] = 'randomizeEmail';
+        $expected['tables']['template']['converters']['email']['unique'] = true;
+        $expected['tables']['template']['converters']['email']['parameters'] = [
+            'domains' => ['example.com'],
+            'min_length' => 10,
+        ];
+        $expected['tables']['template_with_config']['converters']['email']['converter'] = 'randomizeEmail';
+        $expected['tables']['template_with_config']['converters']['email']['unique'] = false;
+        $expected['tables']['template_with_config']['converters']['email']['parameters']['domains'] = ['example.com'];
+
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $expected['tables']['converter_parameter']['converters']['username']['parameters']['converter']['converter'] = 'randomizeText';
+        $expected['tables']['converter_parameter']['converters']['username']['parameters']['converter']['unique'] = true;
+        $expected['tables']['converters_parameter_object']['converters']['chain']['parameters']['converters']['username']['converter'] = 'randomizeText';
+        $expected['tables']['converters_parameter_object']['converters']['chain']['parameters']['converters']['username']['unique'] = true;
+        $expected['tables']['converters_parameter_array']['converters']['chain']['parameters']['converters'][0]['converter'] = 'randomizeText';
+        $expected['tables']['converters_parameter_array']['converters']['chain']['parameters']['converters'][0]['unique'] = true;
+        // phpcs:enable Generic.Files.LineLength.TooLong
+
+        $processor = new ConverterTemplatesProcessor();
+        $processor->process($container);
+
+        $this->assertEquals($expected, $container->toArray());
+    }
+
+    /**
+     * Assert that the processor doesn't do anything if no converter templates were declared.
+     */
+    public function testNoActionIfNoTemplatesDeclared(): void
+    {
+        $container = new Container(
+            (object) [
+                'tables' => (object) [
+                    'users' => (object) [
+                        'converters' => (object) [
+                            'email' => (object) ['converter' => 'uniqueEmail'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $expected = Objects::deepClone($container->getRoot());
+        $processor = new ConverterTemplatesProcessor();
+        $processor->process($container);
+        $this->assertEquals($expected, $container->getRoot());
+    }
+
+    /**
+     * Assert that an exception is thrown when trying to apply converter templates recursively.
+     */
+    public function testErrorOnRecursiveTemplate(): void
+    {
+        $container = new Container(
+            (object) [
+                'tables' => (object) [
+                    'template' => (object) [
+                        'converters' => (object) [
+                            'email' => (object) ['converter' => 'uniqueEmail'],
+                        ],
+                    ],
+                ],
+                'converter_templates' => (object) [
+                    'uniqueEmail' => (object) ['converter' => 'uniqueUser'],
+                    'uniqueUser' => (object) ['converter' => 'randomizeText'],
+                ],
+            ]
+        );
+
+        $processor = new ConverterTemplatesProcessor();
+        $this->expectException(ParseException::class);
+        $processor->process($container);
+    }
+}


### PR DESCRIPTION
This PR adds a config parameter named `converter_templates` (to be confirmed).

It allows to declare reusable converter templates:

```yaml
converter_templates:
    acmeEmail:
        converter: 'randomizeEmail'
        unique: true
        parameters:
            domains: ['acme.com']

tables:
    table1:
        converters:
            email:
                converter: 'acmeEmail'
    table2:
        converters:
            email:
                converter: 'acmeEmail'
                parameters:
                    min_length: 10
```

It also works for converter parameters, for example:

```yaml
tables:
    table1:
        converters:
            email:
                converter: 'chain'
                parameters:
                    - converter: 'acmeEmail'
```